### PR TITLE
Enabling social plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.io/squidfunk/mkdocs-material:latest as BUILDER
+#FROM docker.io/squidfunk/mkdocs-material:latest as BUILDER
+FROM ghcr.io/squidfunk/mkdocs-material:9.5.16 as BUILDER
 WORKDIR /app
 COPY mkdocs.yml /app/mkdocs.yml
 COPY docs /app/docs

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:latest as BUILDER
+FROM ghcr.io/squidfunk/mkdocs-material:9.5.16 as BUILDER
 WORKDIR /app
 
 ENV color=red

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -462,7 +462,7 @@ markdown_extensions:
       repo_url_shorthand: true
 plugins:
   - search
-  # - social # Disabled due to google font being broken: https://github.com/squidfunk/mkdocs-material/issues/6983
+  - social # Disabled due to google font being broken: https://github.com/squidfunk/mkdocs-material/issues/6983
   - git-revision-date-localized:
       enable_creation_date: !ENV [CI, false]
       exclude:


### PR DESCRIPTION
This issue was fixed by the beautiful nerds who maintain the mkdocs-material theme

Fixed by: https://github.com/squidfunk/mkdocs-material/issues/6983