### PR TITLE
fix(broken link): OICD had wrong link for terraform

### DIFF
--- a/docs/kubernetes/k3s/oidc-azure-ad.md
+++ b/docs/kubernetes/k3s/oidc-azure-ad.md
@@ -403,4 +403,4 @@ Congrats!
 
 ## Additional reading
 
-* [Use OIDC login with Terraform](../../automation/iac/terraform/terraform-provider-kubernetes-auth-with-oidc-login)
+* [Use OIDC login with Terraform](../../automation/iac/terraform/terraform-provider-kubernetes-auth-with-oidc-login.md)


### PR DESCRIPTION
Broken link at the bottom of the page