### PR TITLE
Adding the new outdated pages site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ I used to host this documentation on [Digital Ocean](https://m.do.co/c/77be3c3aa
 
 I have done everything I possibly can to reduce the number of trackers on this site. In theory there should be at maximim: 2
 
-Umami or something related, and Matomo. Both of these are self-hosted and run on my home cluster. I dislike cookie banners and trackers as much as the next; which is why you won't ever see them here.
+Umami and Matomo. Both of these are self-hosted and run on my home cluster. I dislike cookie banners and trackers as much as the next; which is why you won't ever see them here.
 
 ## My promise to you
 
@@ -35,6 +35,7 @@ This is more of a gentleman's agreement, however I make the below to you;
 * No AI is used to write documentation
 * The Documentation source code will always remain source available in git (Currently hosted on [GitHub](https://github.com/userbradley/documentation.breadnet.co.uk))
 * [If you open an issue on the repo](https://github.com/userbradley/documentation.breadnet.co.uk/issues), I will look at it and try to fix your issue/ help you
+* You can see what [pages are past review](https://content-review.breadnet.co.uk)
 
 ## Feedback?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -605,6 +605,9 @@ extra:
       enabled: false
       token: 6a2c80ed9b0c4af39dadb53f62452603
   social:
+    - icon: fontawesome/solid/clock
+      link: https://content-review.breadnet.co.uk
+      name: Outdated page review
     - icon: fontawesome/brands/linkedin
       link: https://uk.linkedin.com/in/bradley-stannard
       name: My Linkedin

--- a/overrides/partials/content.html
+++ b/overrides/partials/content.html
@@ -45,10 +45,9 @@
 <div class="admonition warning" role="alert">
     <div class="admonition-title">Outdated page</div>
     <div class="admonition-content">
-        <p>This page was set to be reviewed before {{ page.meta.reviewdate  }} by the page owner.
-            <br>
-            <br>
+        <p>This page was set to be reviewed before {{ page.meta.reviewdate  }} by the page owner.</p>
             <a href="mailto:mkdocs-review@breadnet.co.uk?subject=Page%3A%20{{page_title}}%20is%20outdated&body=Hello%2C%0D%0A%0D%0AThe%20page%20{{ page_url }}%20is%20outdated.%0D%0A%0D%0APlease%20update%20it.">Contact the page Owner (opens default mail client)</a> if you require this page to be updated
+        <p>Outdated pages are managed <a href="https://content-review.breadnet.co.uk">through the outdated page site</a> </p>
     </div>
 </div>
 {% endif %}


### PR DESCRIPTION
This PR adds a new site that runs daily and polls the API for outdated pages

Uses the _api_ (strong word for a static file...) here: https://documentation.breadnet.co.uk/api/pages.json

which generates: https://content-review.breadnet.co.uk