### PR TITLE
feat(kubernetes): [Closes #756] Broken link on kubernetes index

### DIFF
--- a/docs/kubernetes/index.md
+++ b/docs/kubernetes/index.md
@@ -5,12 +5,8 @@ title: Kubernetes
 ## Quick Links
 
 * [Kubectl commands](kb/kubectl-commands.md)
-
-## Folders
-
-* [KB](kb/index.md)
-* [GKE](gke/index.md)
-* [k3s](k3s/index.md)
+* [Downward API](kb/downward-api.md)
+* [View TLS certificates](kb/view-tls-certificates-in-kubernetes.md)
 
 Kubernetes has been awarded its own section as it encompasses the below:
 


### PR DESCRIPTION
This MR removes a broken link to the old KB index page on kubernetes kb. It was removed as it was causing search issues and would show up as the item, meaning people would miss the important things.