### PR TITLE
[Closes #754] Adding page on remving GPS data from images

### DIFF
--- a/docs/kb/exiftool/remove-gps-data-from-images.md
+++ b/docs/kb/exiftool/remove-gps-data-from-images.md
@@ -1,0 +1,48 @@
+---
+title: Remove GPS data from Images
+---
+
+## What's the issue
+
+When uploading an image to some services, or even sharing it with people it will include GPS data as well as other
+information baked in to the image.
+
+This is fine when sharing it with someone you trust, but if you upload it to an S3 bucket to share with more people
+as I often do, then you run the risk of doxxing your self.
+
+## Solution
+
+We can use a tool called `exiftool` which gets its name from the data attached to images, called `Exchangable Image file format` or `EXIF` for shot
+
+Replace `<image.jpg>` with the filename
+
+```shell
+exiftool -all= -overwrite_original_in_place <image.jpg>
+exiftool -gps:all= <image.jpg>
+exiftool "-gps*=" <image.jpg>
+```
+
+### Verify it worked
+
+```shell
+➜ exiftool back.JPG
+ExifTool Version Number         : 13.55
+File Name                       : back.JPG
+Directory                       : .
+File Size                       : 1624 kB
+File Modification Date/Time     : 2026:04:29 01:47:17+01:00
+File Access Date/Time           : 2026:04:29 01:53:42+01:00
+File Inode Change Date/Time     : 2026:04:29 01:50:03+01:00
+File Permissions                : -rw-------
+File Type                       : JPEG
+File Type Extension             : jpg
+MIME Type                       : image/jpeg
+Image Width                     : 3024
+Image Height                    : 4032
+Encoding Process                : Baseline DCT, Huffman coding
+Bits Per Sample                 : 8
+Color Components                : 3
+Y Cb Cr Sub Sampling            : YCbCr4:2:0 (2 2)
+Image Size                      : 3024x4032
+Megapixels                      : 12.2
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,8 @@ nav:
           - kb/drone/index.md
           - Laws: kb/drone/laws.md
           - Stock image marketplaces: kb/drone/stock-image-marketplaces.md
+      - exiftool:
+          - Remove GPS data from Images: kb/exiftool/remove-gps-data-from-images.md
       - Git:
           - Amend commit message: kb/git/amend-commit-message.md
           - Count lines of code in a Git repo: kb/git/count-lines-of-code-in-repo.md


### PR DESCRIPTION
Adding a page on removing GPS data from an image.

This page is a reactive page for https://github.com/pocket-id/pocket-id/issues/1447, capturing these commands in an easier to access format for my self (and who ever else needs it I guess)