### PR TITLE
[Closes #766] Updating copyright date to 2026

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -661,4 +661,4 @@ validation:
     unrecognized_links: info
 extra_css:
   - stylesheets/custom.css
-copyright: Copyright &copy; 2016 - 2025 Bradley Stannard
+copyright: Copyright &copy; 2016 - 2026 Bradley Stannard


### PR DESCRIPTION
Fixed #766 
<img width="320" height="79" alt="image" src="https://github.com/user-attachments/assets/01e4aeae-e57a-459c-878f-5c0a5ae9b99d" />
